### PR TITLE
window match relaxed

### DIFF
--- a/extensions/auto-move-windows/extension.js
+++ b/extensions/auto-move-windows/extension.js
@@ -63,11 +63,11 @@ const WindowMover = new Lang.Class({
                 log ('Cannot find application for window');
             return;
         }
-        let app_id = app.get_id();
+        let app_id = app.get_id().replace('.desktop','');
         for ( let j = 0 ; j < spaces.length; j++ ) {
             let apps_to_space = spaces[j].split(":");
             // Match application id
-            if (apps_to_space[0] == app_id) {
+            if (apps_to_space[0].indexOf(app_id) == 0) {
                 let workspace_num = parseInt(apps_to_space[1]) - 1;
 
                 if (workspace_num >= global.screen.n_workspaces)


### PR DESCRIPTION
# Auto move extension

Some applications has an app_id slightly different from the registered one.
In my case the rule has saved `IBMNotes9.0-url.desktop`, while at runtime it gets `IBMNotes9.0.desktop`.
In order to handle this situation, I relaxed the match logic in this way:
- disregard the extension `.desktop` from the runtime app id
- check if the rule app id starts with the runtime app id 
