### PR TITLE
Clean up whitespace errors

### DIFF
--- a/README
+++ b/README
@@ -71,4 +71,3 @@ GNOME Shell Extensions are distributed under the terms of the GNU General Public
 version 2 or later. See the COPYING file for details.
 Individual extensions may be licensed under different terms, see each source
 file for details.
-

--- a/data/gnome-classic.scss
+++ b/data/gnome-classic.scss
@@ -49,8 +49,8 @@ $variant: 'light';
     -panel-corner-radius: 0;
   }
   &.lock-screen,
-  &.unlock-screen, 
-  &.login-screen { 
+  &.unlock-screen,
+  &.login-screen {
     background-color: transparentize($_bubble_bg_color, 0.5);
     background-gradient-start: transparentize($_bubble_bg_color, 0.5);
     background-gradient-end: transparentize($_bubble_bg_color, 0.5);
@@ -60,9 +60,9 @@ $variant: 'light';
   .popup-menu-arrow { width: 0; height: 0;  } // shell's display: none;
 }
 
-#appMenu { 
-  padding: 0 8px 0 8px; 
-  spinner-image: url("classic-process-working.svg"); 
+#appMenu {
+  padding: 0 8px 0 8px;
+  spinner-image: url("classic-process-working.svg");
 }
 .tile-preview-left.on-primary,
 .tile-preview-right.on-primary,

--- a/extensions/auto-move-windows/Makefile.am
+++ b/extensions/auto-move-windows/Makefile.am
@@ -4,4 +4,3 @@ EXTRA_MODULES = prefs.js
 
 include ../../extension.mk
 include ../../settings.mk
-

--- a/extensions/native-window-placement/Makefile.am
+++ b/extensions/native-window-placement/Makefile.am
@@ -2,4 +2,3 @@ EXTENSION_ID = native-window-placement
 
 include ../../extension.mk
 include ../../settings.mk
-

--- a/extensions/user-theme/Makefile.am
+++ b/extensions/user-theme/Makefile.am
@@ -2,4 +2,3 @@ EXTENSION_ID = user-theme
 
 include ../../extension.mk
 include ../../settings.mk
-

--- a/lib/convenience.js
+++ b/lib/convenience.js
@@ -90,4 +90,3 @@ function getSettings(schema) {
 
     return new Gio.Settings({ settings_schema: schemaObj });
 }
-								  

--- a/po/es.po
+++ b/po/es.po
@@ -3,7 +3,7 @@
 # This file is distributed under the same license as the gnome-shell-extensions package.
 # Jorge González <jorgegonz@svn.gnome.org>, 2011.
 # Nicolás Satragno <nsatragno@gmail.com>, 2011.
-# 
+#
 # Daniel Mustieles <daniel.mustieles@gmail.com>, 2011, 2012., 2013, 2014, 2015.
 #
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -353,4 +353,3 @@ msgstr "Nom"
 #, javascript-format
 msgid "Workspace %d"
 msgstr "Espace de travail %d"
-

--- a/po/hi.po
+++ b/po/hi.po
@@ -337,4 +337,3 @@ msgstr "नाम"
 #, javascript-format
 msgid "Workspace %d"
 msgstr "कार्यस्थान %d"
-

--- a/po/lv.po
+++ b/po/lv.po
@@ -340,4 +340,3 @@ msgstr "Nosaukums"
 #, javascript-format
 msgid "Workspace %d"
 msgstr "Darbvieta %d"
-

--- a/po/mr.po
+++ b/po/mr.po
@@ -332,4 +332,3 @@ msgstr "नाव"
 #, javascript-format
 msgid "Workspace %d"
 msgstr "कार्यक्षेत्र %d"
-

--- a/po/ms.po
+++ b/po/ms.po
@@ -299,4 +299,3 @@ msgstr "Nama"
 #, javascript-format
 msgid "Workspace %d"
 msgstr "Ruangkerja %d"
-


### PR DESCRIPTION
I noticed that [convenience.js](https://github.com/GNOME/gnome-shell-extensions/blob/0cdae2dae04a62a760dc7fa06e1de891338b89a0/lib/convenience.js) had some weird line of only whitespace at the end which seemed to serve no purpose. While I was at it, I decided to check for general whitespace errors using a command found by [Peter Eisentraut](http://peter.eisentraut.org/blog/2014/11/04/checking-whitespace-with-git/) and [StackOverflow](http://stackoverflow.com/questions/9765453/is-gits-semi-secret-empty-tree-object-reliable-and-why-is-there-not-a-symbolic).

```bash
# The hash denotes an empty tree.
diff-tree --check 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD
```