### PR TITLE
Fixed mistake in Esperanto translation

### DIFF
--- a/po/eo.po
+++ b/po/eo.po
@@ -248,7 +248,7 @@ msgstr "La nomo de la etoso, malfermigi de ~/.themes/name/gnome-shell"
 
 #: ../extensions/window-list/extension.js:110
 msgid "Close"
-msgstr "Malfermi"
+msgstr "Fermi"
 
 #: ../extensions/window-list/extension.js:120
 msgid "Unminimize"


### PR DESCRIPTION
I am trying to fix a mistake in the Esperanto translation, which had "Close" translated as "Malfermi" (i.e. "Open") and not as the correct "Fermi". Hopefully this is a working way to submit such a change.